### PR TITLE
*: some optimizes for yamux cache and config

### DIFF
--- a/server/main.go
+++ b/server/main.go
@@ -55,13 +55,11 @@ func newCompStream(conn net.Conn) *compStream {
 // handle multiplex-ed connection
 func handleMux(conn io.ReadWriteCloser, target string, config *yamux.Config) {
 	// stream multiplex
-	var mux *yamux.Session
-	m, err := yamux.Server(conn, config)
+	mux, err := yamux.Server(conn, config)
 	if err != nil {
 		log.Println(err)
 		return
 	}
-	mux = m
 	defer mux.Close()
 
 	for {
@@ -107,6 +105,10 @@ func handleClient(p1, p2 io.ReadWriteCloser) {
 
 func main() {
 	rand.Seed(int64(time.Now().Nanosecond()))
+	if VERSION == "SELFBUILD" {
+		// add more log flags for debugging
+		log.SetFlags(log.LstdFlags | log.Lshortfile)
+	}
 	myApp := cli.NewApp()
 	myApp.Name = "kcptun"
 	myApp.Usage = "kcptun server"


### PR DESCRIPTION
PR Details:

1. maybe `m` is unnecessary here:
    ```
	var mux *yamux.Session
	m, err := yamux.Server(conn, config)
	if err != nil {
		log.Println(err)
		return
	}
	mux = m
	defer mux.Close()
    ```

2. [client] create a new `mux` session when yamux cache miss or cache open failed, if the new one `Open()` succ, put it into cache.

3. set more log flags when selfbuild for easy debugging:
    ```
if VERSION == "SELFBUILD" {
		// add more log flags for debugging
		log.SetFlags(log.LstdFlags | log.Lshortfile)
	}
    ```

4. [client] yamux config init out of the `createConn()` func.
<a href='#crh-start'></a><a href='#crh-data-%7B%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
<a href='https://www.codereviewhub.com/xtaci/kcptun/pull/113?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/xtaci/kcptun/pull/113'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>