### PR TITLE
[#100] POC of nonce-PSK-hmac key exchange [Don't merge]

### DIFF
--- a/client/main.go
+++ b/client/main.go
@@ -385,10 +385,10 @@ func handshake(conn io.ReadWriteCloser, session *kcp.UDPSession) {
 	mac.Reset()
 	mac.Write(SFINISHED)
 	if !hmac.Equal(mac.Sum(nil), sfinished) {
-		log.Println("hmac wrong")
+		log.Fatalln("hmac wrong")
 		return
 	}
 
-	session.SetBlock(block)
+	// session.SetBlock(block)
 	log.Printf("SetBlock: %x", block)
 }

--- a/client/main.go
+++ b/client/main.go
@@ -103,7 +103,7 @@ func main() {
 		},
 		cli.StringFlag{
 			Name:  "remoteaddr, r",
-			Value: "vps:29900",
+			Value: "localhost:29900",
 			Usage: "kcp server address",
 		},
 		cli.StringFlag{

--- a/server/main.go
+++ b/server/main.go
@@ -93,7 +93,6 @@ func handleMux(conn io.ReadWriteCloser, target string, config *yamux.Config, ses
 		if !session.Established() {
 			handshake(p1, session)
 		}
-
 		go handleClient(p1, p2)
 	}
 }
@@ -147,7 +146,7 @@ func handshake(conn io.ReadWriteCloser, session *kcp.UDPSession) {
 	mac := hmac.New(sha256.New, pass)
 	mac.Write(CFINISHED)
 	if !hmac.Equal(mac.Sum(nil), cfinished) {
-		log.Println("hmac wrong")
+		log.Fatalln("hmac wrong")
 		return
 	}
 
@@ -158,7 +157,7 @@ func handshake(conn io.ReadWriteCloser, session *kcp.UDPSession) {
 	conn.Write(sfinished)
 	log.Printf("Write sfinished: %x", sfinished)
 
-	session.SetBlock(block)
+	// session.SetBlock(block)
 	log.Printf("SetBlock: %x", block)
 }
 

--- a/server/main.go
+++ b/server/main.go
@@ -1,7 +1,9 @@
 package main
 
 import (
+	"crypto/hmac"
 	"crypto/sha1"
+	"crypto/sha256"
 	"io"
 	"log"
 	"math/rand"
@@ -20,8 +22,15 @@ import (
 var (
 	// VERSION is injected by buildflags
 	VERSION = "SELFBUILD"
-	// SALT is use for pbkdf2 key expansion
-	SALT = "kcp-go"
+	// sec params
+	snonce []byte
+	cnonce []byte
+	pass   []byte
+	key    []byte
+	crypt  string
+	// Finished message
+	SFINISHED = []byte("SFINISHED")
+	CFINISHED = []byte("CFINISHED")
 )
 
 type compStream struct {
@@ -53,7 +62,7 @@ func newCompStream(conn net.Conn) *compStream {
 }
 
 // handle multiplex-ed connection
-func handleMux(conn io.ReadWriteCloser, target string, config *yamux.Config) {
+func handleMux(conn io.ReadWriteCloser, target string, config *yamux.Config, session *kcp.UDPSession) {
 	// stream multiplex
 	mux, err := yamux.Server(conn, config)
 	if err != nil {
@@ -81,8 +90,76 @@ func handleMux(conn io.ReadWriteCloser, target string, config *yamux.Config) {
 			log.Println("TCP SetWriteBuffer:", err)
 		}
 
+		if !session.Established() {
+			handshake(p1, session)
+		}
+
 		go handleClient(p1, p2)
 	}
+}
+
+func handshake(conn io.ReadWriteCloser, session *kcp.UDPSession) {
+	// handshake
+	cnonce := make([]byte, 16)
+	snonce := make([]byte, 16)
+	conn.Read(cnonce)
+	log.Printf("cnonce: %x", cnonce)
+
+	rand.Read(snonce)
+	pass = pbkdf2.Key(key, append(snonce, cnonce...), 4096, 32, sha1.New)
+	log.Printf("pass: %x", pass)
+	var block kcp.BlockCrypt
+	switch crypt {
+	case "tea":
+		block, _ = kcp.NewTEABlockCrypt(pass[:16])
+	case "xor":
+		block, _ = kcp.NewSimpleXORBlockCrypt(pass)
+	case "none":
+		block, _ = kcp.NewNoneBlockCrypt(pass)
+	case "aes-128":
+		block, _ = kcp.NewAESBlockCrypt(pass[:16])
+	case "aes-192":
+		block, _ = kcp.NewAESBlockCrypt(pass[:24])
+	case "blowfish":
+		block, _ = kcp.NewBlowfishBlockCrypt(pass)
+	case "twofish":
+		block, _ = kcp.NewTwofishBlockCrypt(pass)
+	case "cast5":
+		block, _ = kcp.NewCast5BlockCrypt(pass[:16])
+	case "3des":
+		block, _ = kcp.NewTripleDESBlockCrypt(pass[:24])
+	case "xtea":
+		block, _ = kcp.NewXTEABlockCrypt(pass[:16])
+	case "salsa20":
+		block, _ = kcp.NewSalsa20BlockCrypt(pass)
+	default:
+		crypt = "aes"
+		block, _ = kcp.NewAESBlockCrypt(pass)
+	}
+	conn.Write(snonce)
+	log.Printf("snonce: %x", snonce)
+
+	cfinished := make([]byte, sha256.Size)
+	log.Printf("Reading cfinished...")
+	conn.Read(cfinished)
+	log.Printf("Read cfinished: %x", cfinished)
+
+	mac := hmac.New(sha256.New, pass)
+	mac.Write(CFINISHED)
+	if !hmac.Equal(mac.Sum(nil), cfinished) {
+		log.Println("hmac wrong")
+		return
+	}
+
+	mac.Reset()
+	mac.Write(SFINISHED)
+	sfinished := mac.Sum(nil)
+	log.Printf("Writing sfinished...")
+	conn.Write(sfinished)
+	log.Printf("Write sfinished: %x", sfinished)
+
+	session.SetBlock(block)
+	log.Printf("SetBlock: %x", block)
 }
 
 func handleClient(p1, p2 io.ReadWriteCloser) {
@@ -232,39 +309,11 @@ func main() {
 			nodelay, interval, resend, nc = 1, 10, 2, 1
 		}
 
-		crypt := c.String("crypt")
-		pass := pbkdf2.Key([]byte(c.String("key")), []byte(SALT), 4096, 32, sha1.New)
-		var block kcp.BlockCrypt
-		switch crypt {
-		case "tea":
-			block, _ = kcp.NewTEABlockCrypt(pass[:16])
-		case "xor":
-			block, _ = kcp.NewSimpleXORBlockCrypt(pass)
-		case "none":
-			block, _ = kcp.NewNoneBlockCrypt(pass)
-		case "aes-128":
-			block, _ = kcp.NewAESBlockCrypt(pass[:16])
-		case "aes-192":
-			block, _ = kcp.NewAESBlockCrypt(pass[:24])
-		case "blowfish":
-			block, _ = kcp.NewBlowfishBlockCrypt(pass)
-		case "twofish":
-			block, _ = kcp.NewTwofishBlockCrypt(pass)
-		case "cast5":
-			block, _ = kcp.NewCast5BlockCrypt(pass[:16])
-		case "3des":
-			block, _ = kcp.NewTripleDESBlockCrypt(pass[:24])
-		case "xtea":
-			block, _ = kcp.NewXTEABlockCrypt(pass[:16])
-		case "salsa20":
-			block, _ = kcp.NewSalsa20BlockCrypt(pass)
-		default:
-			crypt = "aes"
-			block, _ = kcp.NewAESBlockCrypt(pass)
-		}
+		key = []byte(c.String("key"))
+		crypt = c.String("crypt")
 
 		datashard, parityshard := c.Int("datashard"), c.Int("parityshard")
-		lis, err := kcp.ListenWithOptions(c.String("listen"), block, datashard, parityshard)
+		lis, err := kcp.ListenWithOptions(c.String("listen"), nil, datashard, parityshard)
 		if err != nil {
 			log.Fatal(err)
 		}
@@ -314,9 +363,9 @@ func main() {
 				conn.SetKeepAlive(keepalive)
 
 				if nocomp {
-					go handleMux(conn, target, config)
+					go handleMux(conn, target, config, conn)
 				} else {
-					go handleMux(newCompStream(conn), target, config)
+					go handleMux(newCompStream(conn), target, config, conn)
 				}
 			} else {
 				log.Println(err)


### PR DESCRIPTION
在[#100](https://github.com/xtaci/kcptun/issues/100)提到的nonce-PSK一个参考实现，但是因为kcp-go的包头目前与blockCrypt强耦合，block握手完成后后无法复用原连接，想听听@xtaci的意见。
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/xtaci/kcptun/pull/158%23issuecomment-242250342%22%2C%20%22https%3A//github.com/xtaci/kcptun/pull/158%23issuecomment-242270802%22%2C%20%22https%3A//github.com/xtaci/kcptun/pull/158%23issuecomment-242271384%22%2C%20%22https%3A//github.com/xtaci/kcptun/pull/158%23issuecomment-242272017%22%2C%20%22https%3A//github.com/xtaci/kcptun/pull/158%23issuecomment-242272139%22%2C%20%22https%3A//github.com/xtaci/kcptun/pull/158%23issuecomment-242272370%22%2C%20%22https%3A//github.com/xtaci/kcptun/pull/158%23issuecomment-242272504%22%2C%20%22https%3A//github.com/xtaci/kcptun/pull/158%23issuecomment-242273144%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/xtaci/kcptun/pull/158%23issuecomment-242250342%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22%5Cu7c97%5Cu7c97%5Cu770b%5Cu4e86%5Cu4e0b%3A%5Cr%5Cn1.%20%5Cu65e2%5Cu7136%5Cu90fd%5Cu8981%5Cu4ea4%5Cu6362nonce%5Cu4e86%5Cuff0c%5Cu4e3a%5Cu4ec0%5Cu4e48%5Cu4e0d%5Cu76f4%5Cu63a5%5Cu7528DH%5Cu5462%5Cuff1f%5Cr%5Cn2.%20%5Cu8fd9%5Cu6837%5Cu5bc6%5Cu6587%5Cu53ef%5Cu4ee5%5Cu7528%20HMAC%28message%2C%20PSK%29%20%2B%20BlockCrypt%28message%2C%20DH-KEY%29%22%2C%20%22created_at%22%3A%20%222016-08-25T00%3A39%3A39Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/2346725%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/xtaci%22%7D%7D%2C%20%7B%22body%22%3A%20%22DH%5Cu662f%5Cu6ca1%5Cu95ee%5Cu9898%5Cu7684%5Cuff0c%5Cu53ea%5Cu4e0d%5Cu8fc7%5Cu6ca1%5Cu6709%5Cu529e%5Cu6cd5%5Cu50cfPSK%5Cu8fd9%5Cu6837%5Cu9650%5Cu5236%5Cu8fde%5Cu63a5%5Cu4e86%5Cu5427%22%2C%20%22created_at%22%3A%20%222016-08-25T03%3A18%3A02Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1702340%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/tcz001%22%7D%7D%2C%20%7B%22body%22%3A%20%22%5Cu554a%5Cuff0c%5Cu660e%5Cu767d%5Cu4f60%5Cu7684%5Cu610f%5Cu601d%5Cu4e86%5Cuff0cHMAC-PSK%5Cu7528%5Cu6765%5Cu505aAuthentication%5Cuff0c%5Cu8fd9%5Cu4e2a%5Cu53ef%5Cu4ee5%5Cu6709%5Cuff0c%5Cu53ea%5Cu4e0d%5Cu8fc7%5Cu8c8c%5Cu4f3c%5Cu73b0%5Cu5728%5Cu7684packet%5Cu91cc%5Cu5df2%5Cu7ecf%5Cu6709%5Cu4e00%5Cu5c42%5Cu6821%5Cu9a8c%5Cu4e86%5Cuff0c%5Cu4f1a%5Cu4e0d%5Cu4f1a%5Cu6709%5Cu70b9%5Cu91cd%5Cu590d%5Cuff1f%22%2C%20%22created_at%22%3A%20%222016-08-25T03%3A23%3A16Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1702340%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/tcz001%22%7D%7D%2C%20%7B%22body%22%3A%20%22%5Cu662f%5Cu7684%5Cuff0c%5Cu5c31%5Cu662f%5Cu91cd%5Cu590d%5Cu4e86%5Cuff0c%5Cu6240%5Cu4ee5%5Cu6211%5Cu8fd8%5Cu662f%5Cu89c9%5Cu5f97%5Cuff0c%5Cu5728%5Cu5e94%5Cu7528%5Cu5c42%5Cu505a%5Cu52a0%5Cu5bc6%5Cu6bd4%5Cu8f83%5Cu597d%5Cuff0c%5Cu5176%5Cu5b9e%5Cu5f88%5Cu7b80%5Cu5355%5Cuff0c%5Cu5b9e%5Cu73b0%5Cu4e00%5Cu4e2aTLS%5Cu5c42%5Cuff0c%5Cu6bd4%5Cu5982%5Cuff1a%5Cr%5Cnhttps%3A//golang.org/pkg/crypto/tls/%23Client%20%5Cu5c31%5Cu4ec0%5Cu4e48%5Cu90fd%5Cu89e3%5Cu51b3%5Cu4e86%5Cu3002%5Cr%5Cn%5Cr%5Cn%5Cu672c%5Cu8d28%5Cu4e0a%2Ckcptun%5Cu53ea%5Cu505a%5Cu6df7%5Cu6dc6%5Cu548c%5Cu57fa%5Cu672c%5Cu7684crc%5Cu6821%5Cu9a8c%5Cu5c31%5Cu884c%5Cu4e86%5Cu3002%20%5Cu4f60%5Cu89c9%5Cu5f97%5Cu5462%5Cu3002%22%2C%20%22created_at%22%3A%20%222016-08-25T03%3A28%3A50Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/2346725%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/xtaci%22%7D%7D%2C%20%7B%22body%22%3A%20%22%5Cu5728PSK%5Cu4e0d%5Cu6cc4%5Cu6f0f%5Cu7684%5Cu60c5%5Cu51b5%5Cu4e0b%5Cuff0c%5Cu5b89%5Cu5168%5Cu6027%5Cu5176%5Cu5b9e%5Cu662f%5Cu7b49%5Cu540c%5Cu4e8eRSA%5Cu7684%5Cuff0c%20%5Cu4e0d%5Cu8fc7%5Cu56e0%5Cu4e3a%5Cu6ca1%5Cu6709%5Cu52a8%5Cu6001KEY%5Cuff0c%5Cu6240%5Cu4ee5%5Cu6ca1%5Cu6709forward%20secrecy%5Cu3002%22%2C%20%22created_at%22%3A%20%222016-08-25T03%3A29%3A59Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/2346725%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/xtaci%22%7D%7D%2C%20%7B%22body%22%3A%20%22%5Cu55ef%5Cuff0c%5Cu540c%5Cu610f%5Cuff0c%5Cu90a3%5Cu53ef%5Cu80fd%5Cu73b0%5Cu5728%5Cu63d0%5Cu4f9b%5Cu7684%5Cu8fd9%5Cu4e2ablock%5Cu65b9%5Cu5f0f%5Cu6709%5Cu70b9%5Cu591a%5Cu4f59%5Cu4e86%22%2C%20%22created_at%22%3A%20%222016-08-25T03%3A31%3A58Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1702340%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/tcz001%22%7D%7D%2C%20%7B%22body%22%3A%20%22%5Cu6216%5Cu8005%5Cu8bf4%5Cu53ef%5Cu4ee5%5Cu7528tls%5Cu66ff%5Cu6362%5Cu6389%5Cu8fd9%5Cu5c42%22%2C%20%22created_at%22%3A%20%222016-08-25T03%3A33%3A06Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1702340%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/tcz001%22%7D%7D%2C%20%7B%22body%22%3A%20%22%5Cu6211%5Cu4e4b%5Cu524d%5Cu7684%5Cu60f3%5Cu6cd5%5Cu5176%5Cu5b9e%5Cu548cWPA%5Cu5f88%5Cu50cf%5Cuff0c%5Cu901a%5Cu8fc7PSK%5Cu6765%5Cu540c%5Cu65f6%5Cu8d77%5Cu5230Encryption-as-Authentication%5Cu7684%5Cu4f5c%5Cu7528%5Cuff0c%5Cu540c%5Cu65f6%5Cu7528nonce%5Cu907f%5Cu514dPSK%20replay%5Cuff0c%5Cu56e0%5Cu4e3a%5Cu5b9e%5Cu9645%5Cu4e0a%5Cu4efb%5Cu4f55%5Cu4e2d%5Cu95f4%5Cu4eba%5Cu90fd%5Cu53ef%5Cu4ee5%5Cu901a%5Cu8fc7pbkdf2%5Cu540e%5Cu7684pass%22%2C%20%22created_at%22%3A%20%222016-08-25T03%3A39%3A03Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1702340%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/tcz001%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [ ] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/xtaci/kcptun/pull/158#issuecomment-242250342'>General Comment</a></b>
- <a href='https://github.com/xtaci'><img border=0 src='https://avatars.githubusercontent.com/u/2346725?v=3' height=16 width=16'></a> 粗粗看了下:
1. 既然都要交换nonce了，为什么不直接用DH呢？
2. 这样密文可以用 HMAC(message, PSK) + BlockCrypt(message, DH-KEY)
- <a href='https://github.com/tcz001'><img border=0 src='https://avatars.githubusercontent.com/u/1702340?v=3' height=16 width=16'></a> DH是没问题的，只不过没有办法像PSK这样限制连接了吧
- <a href='https://github.com/tcz001'><img border=0 src='https://avatars.githubusercontent.com/u/1702340?v=3' height=16 width=16'></a> 啊，明白你的意思了，HMAC-PSK用来做Authentication，这个可以有，只不过貌似现在的packet里已经有一层校验了，会不会有点重复？
- <a href='https://github.com/xtaci'><img border=0 src='https://avatars.githubusercontent.com/u/2346725?v=3' height=16 width=16'></a> 是的，就是重复了，所以我还是觉得，在应用层做加密比较好，其实很简单，实现一个TLS层，比如：
https://golang.org/pkg/crypto/tls/#Client 就什么都解决了。
本质上,kcptun只做混淆和基本的crc校验就行了。 你觉得呢。
- <a href='https://github.com/xtaci'><img border=0 src='https://avatars.githubusercontent.com/u/2346725?v=3' height=16 width=16'></a> 在PSK不泄漏的情况下，安全性其实是等同于RSA的， 不过因为没有动态KEY，所以没有forward secrecy。
- <a href='https://github.com/tcz001'><img border=0 src='https://avatars.githubusercontent.com/u/1702340?v=3' height=16 width=16'></a> 嗯，同意，那可能现在提供的这个block方式有点多余了
- <a href='https://github.com/tcz001'><img border=0 src='https://avatars.githubusercontent.com/u/1702340?v=3' height=16 width=16'></a> 或者说可以用tls替换掉这层
- <a href='https://github.com/tcz001'><img border=0 src='https://avatars.githubusercontent.com/u/1702340?v=3' height=16 width=16'></a> 我之前的想法其实和WPA很像，通过PSK来同时起到Encryption-as-Authentication的作用，同时用nonce避免PSK replay，因为实际上任何中间人都可以通过pbkdf2后的pass


<a href='https://www.codereviewhub.com/xtaci/kcptun/pull/158?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/xtaci/kcptun/pull/158?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/xtaci/kcptun/pull/158'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>