### PR TITLE
add support for json configuration

### DIFF
--- a/client/config.go
+++ b/client/config.go
@@ -1,5 +1,10 @@
 package main
 
+import (
+	"encoding/json"
+	"os"
+)
+
 type Config struct {
 	LocalAddr    string `json:"localaddr"`
 	RemoteAddr   string `json:"remoteaddr"`
@@ -22,4 +27,18 @@ type Config struct {
 	NoCongestion int    `json:"nc"`
 	SockBuf      int    `json:"sockbuf"`
 	KeepAlive    int    `json:"keepalive"`
+}
+
+func parseJsonConfig(config *Config, path string) (err error) {
+	file, err := os.Open(path) // For read access.
+	if err != nil {
+		return
+	}
+	defer file.Close()
+
+	if err = json.NewDecoder(file).Decode(config); err != nil {
+		return
+	}
+
+	return
 }

--- a/client/main.go
+++ b/client/main.go
@@ -202,6 +202,9 @@ func main() {
 			Value:  10, // nat keepalive interval in seconds
 			Hidden: true,
 		},
+		cli.StringFlag{
+			Name: "c",
+		},
 	}
 	myApp.Action = func(c *cli.Context) error {
 		config := Config{}
@@ -226,6 +229,9 @@ func main() {
 		config.NoCongestion = c.Int("nc")
 		config.SockBuf = c.Int("sockbuf")
 		config.KeepAlive = c.Int("keepalive")
+
+		//Now only support json config file
+		parseJsonConfig(&config, c.String("c"))
 
 		switch config.Mode {
 		case "normal":

--- a/client/main.go
+++ b/client/main.go
@@ -203,7 +203,9 @@ func main() {
 			Hidden: true,
 		},
 		cli.StringFlag{
-			Name: "c",
+			Name:  "c",
+			Value: "", // when the value is not empty, the config path must exists
+			Usage: "config from json file, which will override the command from shell",
 		},
 	}
 	myApp.Action = func(c *cli.Context) error {
@@ -230,8 +232,10 @@ func main() {
 		config.SockBuf = c.Int("sockbuf")
 		config.KeepAlive = c.Int("keepalive")
 
-		//Now only support json config file
-		parseJsonConfig(&config, c.String("c"))
+		if c.String("c") != "" {
+			err := parseJsonConfig(&config, c.String("c"))
+			checkError(err)
+		}
 
 		switch config.Mode {
 		case "normal":

--- a/server/config.go
+++ b/server/config.go
@@ -1,5 +1,10 @@
 package main
 
+import (
+	"encoding/json"
+	"os"
+)
+
 type Config struct {
 	Listen       string `json:"listen"`
 	Target       string `json:"target"`
@@ -20,4 +25,18 @@ type Config struct {
 	NoCongestion int    `json:"nc"`
 	SockBuf      int    `json:"sockbuf"`
 	KeepAlive    int    `json:"keepalive"`
+}
+
+func parseJsonConfig(config *Config, path string) (err error) {
+	file, err := os.Open(path) // For read access.
+	if err != nil {
+		return
+	}
+	defer file.Close()
+
+	if err = json.NewDecoder(file).Decode(config); err != nil {
+		return
+	}
+
+	return
 }

--- a/server/main.go
+++ b/server/main.go
@@ -226,7 +226,9 @@ func main() {
 			Hidden: true,
 		},
 		cli.StringFlag{
-			Name: "c",
+			Name:  "c",
+			Value: "", // when the value is not empty, the config path must exists
+			Usage: "config from json file, which will override the command from shell",
 		},
 	}
 	myApp.Action = func(c *cli.Context) error {
@@ -251,8 +253,11 @@ func main() {
 		config.SockBuf = c.Int("sockbuf")
 		config.KeepAlive = c.Int("keepalive")
 
-		//Now only support json config file
-		parseJsonConfig(&config, c.String("c"))
+		if c.String("c") != "" {
+			//Now only support json config file
+			err := parseJsonConfig(&config, c.String("c"))
+			checkError(err)
+		}
 
 		switch config.Mode {
 		case "normal":

--- a/server/main.go
+++ b/server/main.go
@@ -225,6 +225,9 @@ func main() {
 			Value:  10, // nat keepalive interval in seconds
 			Hidden: true,
 		},
+		cli.StringFlag{
+			Name: "c",
+		},
 	}
 	myApp.Action = func(c *cli.Context) error {
 		config := Config{}
@@ -247,6 +250,9 @@ func main() {
 		config.NoCongestion = c.Int("nc")
 		config.SockBuf = c.Int("sockbuf")
 		config.KeepAlive = c.Int("keepalive")
+
+		//Now only support json config file
+		parseJsonConfig(&config, c.String("c"))
 
 		switch config.Mode {
 		case "normal":


### PR DESCRIPTION
The project of "github.com/urfave/cli" has not supported a JSON InputSource util now.
[issue here](https://github.com/urfave/cli/pull/470)

So we can use this pr to support JSON config file instead of using JSON InputSource by cli support temporarily.
<a href='#crh-start'></a><a href='#crh-data-%7B%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
<a href='https://www.codereviewhub.com/xtaci/kcptun/pull/165?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/xtaci/kcptun/pull/165'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>