### PR TITLE
Implement #271 The [Client Know The Target Addr]

### DIFF
--- a/client/config.go
+++ b/client/config.go
@@ -7,6 +7,7 @@ import (
 
 // Config for client
 type Config struct {
+	TargetAddr   string `json:"targetaddr"`
 	LocalAddr    string `json:"localaddr"`
 	RemoteAddr   string `json:"remoteaddr"`
 	Key          string `json:"key"`

--- a/client/main.go
+++ b/client/main.go
@@ -355,6 +355,15 @@ func main() {
 		waitConn := func() *smux.Session {
 			for {
 				if session, err := createConn(); err == nil {
+					//Check the ta flags
+					if config.TargetAddr != "-1" {
+						pTellTargetAddr, err := session.OpenStream()
+						if err != nil {
+							log.Println("Can not open stream:", err)
+						} else {
+							pTellTargetAddr.Write([]byte(config.TargetAddr)) //Write config.TargetAddr to remote
+						}
+					}
 					return session
 				} else {
 					time.Sleep(time.Second)

--- a/server/config.go
+++ b/server/config.go
@@ -7,6 +7,7 @@ import (
 
 // Config for server
 type Config struct {
+	ClientKnowTheTargetAddr string `json:"clientknowthetargetaddr"`
 	Listen       string `json:"listen"`
 	Target       string `json:"target"`
 	Key          string `json:"key"`

--- a/server/main.go
+++ b/server/main.go
@@ -75,14 +75,14 @@ func handleMux(conn io.ReadWriteCloser, config *Config) {
 			return
 		}
 		ttan := make(chan []byte, 1)
-		go func () {
+		go func (p1 *smux.Stream) {
 			_, err := p1.Read(ttaBuf)
 			if err != nil {
 				log.Println("Read ttaBuf got error", err)
 				return
 			}
 			ttan <- ttaBuf
-		}()
+		}(p1)
 
 		var ttbyte []byte
 		select {

--- a/server/main.go
+++ b/server/main.go
@@ -84,16 +84,18 @@ func handleMux(conn io.ReadWriteCloser, config *Config) {
 			ttan <- ttaBuf
 		}()
 
+		var ttbyte []byte
 		select {
-		case ttan := <- ttan:
-			log.Println("Got ttan:", string(ttan))
+		case res := <- ttan:
+			log.Println("Got ttan:", string(res))
+		        ttbyte = res
 		case <- time.After( 2 * time.Second):
 			log.Println("Read ttan timeout:")
 			return
 		}
 		log.Println(string(ttaBuf))
-		log.Println("ttan was: ", ttan)
-		target = string(ttaBuf)
+		log.Println("ttan was: ", string(ttbyte))
+		target = string(ttbyte)
 		if strings.Contains(target, ":") == false {
 			log.Println("Target flags not right:", ttaBuf)
 			return

--- a/server/main.go
+++ b/server/main.go
@@ -17,6 +17,7 @@ import (
 	"github.com/xtaci/smux"
 	"gopkg.in/fatih/pool.v2"
 	"strings"
+	"github.com/google/gops/agent"
 )
 
 var (
@@ -185,6 +186,9 @@ func checkError(err error) {
 }
 
 func main() {
+	if err := agent.Start(); err != nil {
+		log.Fatal(err)
+	}
 	rand.Seed(int64(time.Now().Nanosecond()))
 	if VERSION == "SELFBUILD" {
 		// add more log flags for debugging

--- a/server/main.go
+++ b/server/main.go
@@ -308,6 +308,7 @@ func main() {
 	}
 	myApp.Action = func(c *cli.Context) error {
 		config := Config{}
+		config.ClientKnowTheTargetAddr = c.String("clientknowthetargetaddr")
 		config.Listen = c.String("listen")
 		config.Target = c.String("target")
 		config.Key = c.String("key")


### PR DESCRIPTION
A new Listen Flag

see https://github.com/xtaci/kcptun/issues/271

RFC-20161114001: The [Client Know The Target Addr] listen flag


Quick and dirty , but it works.

Signed-off-by: ZhiFeng Hu <hufeng1987@gmail.com>
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/xtaci/kcptun/pull/273%23issuecomment-260833541%22%2C%20%22https%3A//github.com/xtaci/kcptun/pull/273%23issuecomment-260845150%22%2C%20%22https%3A//github.com/xtaci/kcptun/pull/273%23issuecomment-260845241%22%2C%20%22https%3A//github.com/xtaci/kcptun/pull/273%23issuecomment-260850441%22%2C%20%22https%3A//github.com/xtaci/kcptun/pull/273%23issuecomment-260850580%22%2C%20%22https%3A//github.com/xtaci/kcptun/pull/273%23issuecomment-260850959%22%2C%20%22https%3A//github.com/xtaci/kcptun/pull/273%23issuecomment-271234367%22%2C%20%22https%3A//github.com/xtaci/kcptun/pull/273%23issuecomment-271234491%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/xtaci/kcptun/pull/273%23issuecomment-260833541%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22i%20think%20it%27s%20better%20to%20add%20a%20frameType%20in%20smux%2C%20like%20cmdOption%2C%20to%20push%20options%20to%20the%20remote.%5Cn%22%2C%20%22created_at%22%3A%20%222016-11-16T02%3A14%3A17Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/2346725%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/xtaci%22%7D%7D%2C%20%7B%22body%22%3A%20%22Oh%2C%20I%20have%20no%20willing%20to%20modify%20your%20smux.%20but%20you%20can%20implement%20your%20solution%20if%20you%20have%20time.%5Cn%22%2C%20%22created_at%22%3A%20%222016-11-16T03%3A38%3A53Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/278153%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/netroby%22%7D%7D%2C%20%7B%22body%22%3A%20%22As%20i%20thought%2C%20SMUX%20must%20keep%20simple%20and%20fast.%20so%20i%20prefer%20change%20/modify%20kcp%20client/server%20%5Cn%22%2C%20%22created_at%22%3A%20%222016-11-16T03%3A39%3A38Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/278153%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/netroby%22%7D%7D%2C%20%7B%22body%22%3A%20%22%40xtaci%20we%20already%20deploy%20this%20patch%20at%20our%20production%20environment%2C%20works%20like%20a%20boss.%20thanks%20your%20hard%20work%5Cn%22%2C%20%22created_at%22%3A%20%222016-11-16T04%3A20%3A43Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/278153%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/netroby%22%7D%7D%2C%20%7B%22body%22%3A%20%22great.%5Cn%22%2C%20%22created_at%22%3A%20%222016-11-16T04%3A22%3A14Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/2346725%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/xtaci%22%7D%7D%2C%20%7B%22body%22%3A%20%22If%20some%20one%20looking%20for%20outland%20redundancy%2C%20multiple%20redundancy%20architecture%2C%20This%20patch%20may%20useful.%20%5Cn%22%2C%20%22created_at%22%3A%20%222016-11-16T04%3A25%3A11Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/278153%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/netroby%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3Ashipit%3A%22%2C%20%22created_at%22%3A%20%222017-01-09T08%3A51%3A38Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/127621%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/abitduck%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3Ashipit%3A%3Agun%3A%22%2C%20%22created_at%22%3A%20%222017-01-09T08%3A52%3A27Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/127621%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/abitduck%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%7D%2C%20%22approved%22%3A%20%7B%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [ ] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/xtaci/kcptun/pull/273#issuecomment-260833541'>General Comment</a></b>
- <a href='https://github.com/xtaci'><img border=0 src='https://avatars.githubusercontent.com/u/2346725?v=3' height=16 width=16'></a> i think it's better to add a frameType in smux, like cmdOption, to push options to the remote.
- <a href='https://github.com/netroby'><img border=0 src='https://avatars.githubusercontent.com/u/278153?v=3' height=16 width=16'></a> Oh, I have no willing to modify your smux. but you can implement your solution if you have time.
- <a href='https://github.com/netroby'><img border=0 src='https://avatars.githubusercontent.com/u/278153?v=3' height=16 width=16'></a> As i thought, SMUX must keep simple and fast. so i prefer change /modify kcp client/server
- <a href='https://github.com/netroby'><img border=0 src='https://avatars.githubusercontent.com/u/278153?v=3' height=16 width=16'></a> @xtaci we already deploy this patch at our production environment, works like a boss. thanks your hard work
- <a href='https://github.com/xtaci'><img border=0 src='https://avatars.githubusercontent.com/u/2346725?v=3' height=16 width=16'></a> great.
- <a href='https://github.com/netroby'><img border=0 src='https://avatars.githubusercontent.com/u/278153?v=3' height=16 width=16'></a> If some one looking for outland redundancy, multiple redundancy architecture, This patch may useful.
- <a href='https://github.com/abitduck'><img border=0 src='https://avatars.githubusercontent.com/u/127621?v=3' height=16 width=16'></a> :shipit:
- <a href='https://github.com/abitduck'><img border=0 src='https://avatars.githubusercontent.com/u/127621?v=3' height=16 width=16'></a> :shipit::gun:


<a href='https://www.codereviewhub.com/xtaci/kcptun/pull/273?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/xtaci/kcptun/pull/273?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/xtaci/kcptun/pull/273'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>