### PR TITLE
增加TCP模式

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,31 @@
 
 <img src="kcptun.png" alt="kcptun" height="300px"/>
 
+
+## kcptun(tcp) - kcptun + tcp模式
+### 什么是tcp模式?
+原版kcptun使用UDP传输层，大流量容易被ISP封停(只能重启拨号或等待一段时间才能恢复).  
+kcptun(tcp)参考<del>抄袭</del>[finalspeed](https://github.com/d1sm/finalspeed), 用libpcap构造伪TCP包，替代UDP传输.  
+
+### Usage
+由于使用pcap发包，需要root权限  
+windows用户需下载[wincap](https://www.winpcap.org/install/default.htm)  
+kcptun(tcp)与原版参数一致，只是多了2个参数：  
+```
+--tcp                            开启tcp模式，否则和原版一致
+--interface value, -i value      指定network interface, 如eth0, 如果没有指定, 启动后手动选择.
+```  
+注意：客户端只能开一个连接，即--conn 1
+
+### Install
+安装pcap Developer's Pack  
+windows: 下载[Wincap Developer's Pack](https://www.winpcap.org/devel.htm)  
+ubuntu: ```sudo apt-get install libpcap-dev```  
+或者自行编译libpcap: [http://www.tcpdump.org/](http://www.tcpdump.org/)  
+
+### 注意
+kcptun(tcp) 启动时会修改防火墙规则, 详见tcp.go
+
 ### QuickStart
 
 Download precompiled [Releases](https://github.com/xtaci/kcptun/releases).

--- a/client/config.go
+++ b/client/config.go
@@ -32,6 +32,8 @@ type Config struct {
 	Log          string `json:"log"`
 	SnmpLog      string `json:"snmplog"`
 	SnmpPeriod   int    `json:"snmpperiod"`
+	Tcp          bool   `json:"tcp"`
+    Interface    string `json:"interface"`
 }
 
 func parseJSONConfig(config *Config, path string) error {

--- a/client/main.go
+++ b/client/main.go
@@ -246,6 +246,15 @@ func main() {
 			Value: "", // when the value is not empty, the config path must exists
 			Usage: "config from json file, which will override the command from shell",
 		},
+		cli.BoolFlag{
+            Name:"tcp",
+            Usage:"tcp mode",
+        },
+        cli.StringFlag{
+            Name:   "interface,i",
+            Value:  "",
+            Usage:  "interface for live capture",
+        },
 	}
 	myApp.Action = func(c *cli.Context) error {
 		config := Config{}
@@ -274,6 +283,8 @@ func main() {
 		config.Log = c.String("log")
 		config.SnmpLog = c.String("snmplog")
 		config.SnmpPeriod = c.Int("snmpperiod")
+		config.Tcp = c.Bool("tcp")
+        config.Interface = c.String("interface")
 
 		if c.String("c") != "" {
 			err := parseJSONConfig(&config, c.String("c"))
@@ -357,8 +368,23 @@ func main() {
 		smuxConfig.MaxReceiveBuffer = config.SockBuf
 		smuxConfig.KeepAliveInterval = time.Duration(config.KeepAlive) * time.Second
 
+        var tcp *kcp.FakeTCP
+        if config.Tcp {
+            log.Println("tcp mode")
+            tcp = new(kcp.FakeTCP)
+            if err := tcp.Initialize(config.RemoteAddr, config.Interface, false); err != nil {
+                panic(err)
+            }
+        }
+
 		createConn := func() (*smux.Session, error) {
-			kcpconn, err := kcp.DialWithOptions(config.RemoteAddr, block, config.DataShard, config.ParityShard)
+			var kcpconn *kcp.UDPSession
+            var err error
+            if config.Tcp {
+                kcpconn, err = kcp.DialTCPWithOptions(config.RemoteAddr, block, config.DataShard, config.ParityShard, tcp)
+            } else {
+                kcpconn, err = kcp.DialWithOptions(config.RemoteAddr, block, config.DataShard, config.ParityShard)
+            }
 			if err != nil {
 				return nil, errors.Wrap(err, "createConn()")
 			}

--- a/server/config.go
+++ b/server/config.go
@@ -30,6 +30,8 @@ type Config struct {
 	SnmpLog      string `json:"snmplog"`
 	SnmpPeriod   int    `json:"snmpperiod"`
 	Pprof        bool   `json:"pprof"`
+	Tcp          bool   `json:"tcp"`
+    Interface    string `json:"interface"`
 }
 
 func parseJSONConfig(config *Config, path string) error {

--- a/server/main.go
+++ b/server/main.go
@@ -261,6 +261,15 @@ func main() {
 			Value: "", // when the value is not empty, the config path must exists
 			Usage: "config from json file, which will override the command from shell",
 		},
+		cli.BoolFlag{
+            Name:"tcp",
+            Usage:"tcp mode",
+        },
+        cli.StringFlag{
+            Name:   "interface,i",
+            Value:  "",
+            Usage:  "interface for live capture",
+        },
 	}
 	myApp.Action = func(c *cli.Context) error {
 		config := Config{}
@@ -287,6 +296,8 @@ func main() {
 		config.SnmpLog = c.String("snmplog")
 		config.SnmpPeriod = c.Int("snmpperiod")
 		config.Pprof = c.Bool("pprof")
+		config.Tcp = c.Bool("tcp")
+        config.Interface = c.String("interface")
 
 		if c.String("c") != "" {
 			//Now only support json config file
@@ -344,7 +355,15 @@ func main() {
 			block, _ = kcp.NewAESBlockCrypt(pass)
 		}
 
-		lis, err := kcp.ListenWithOptions(config.Listen, block, config.DataShard, config.ParityShard)
+        var err error
+        var lis *kcp.Listener
+        if config.Tcp {
+            log.Println("tcp mode")
+            lis, err = kcp.ListenTCPWithOptions(config.Listen, block, config.DataShard, config.ParityShard, config.Interface)
+        } else {
+        	lis, err = kcp.ListenWithOptions(config.Listen, block, config.DataShard, config.ParityShard)
+    	}
+
 		checkError(err)
 		log.Println("listening on:", lis.Addr())
 		log.Println("target:", config.Target)


### PR DESCRIPTION
原版kcptun使用UDP传输层，大流量容易被ISP封停(只能重启拨号或等待一段时间才能恢复).  
)参考<del>抄袭</del>[finalspeed](https://github.com/d1sm/finalspeed), 用libpcap构造伪TCP包，替代UDP传输.   
没有修改原版的任何逻辑，只是重新实现了UDPConn
**用法：** [https://github.com/vitamincpp/kcptun/tree/pr](https://github.com/vitamincpp/kcptun/tree/pr)
参数与原版一致，多了2个参数: --tcp 和 --interface
**Bug**：
服务器端UDPSession关闭后，会有资源泄漏：看tcp.go的TODO...
<a href='#crh-start'></a><a href='#crh-data-%7B%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
<a href='https://www.codereviewhub.com/xtaci/kcptun/pull/426?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/xtaci/kcptun/pull/426'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>