### PR TITLE
reduce docker image size by using multi stage build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,11 @@
-FROM golang:alpine
+FROM golang:alpine as builder
 MAINTAINER xtaci <daniel820313@gmail.com>
 RUN apk update && \
     apk upgrade && \
     apk add git
 RUN go get -ldflags "-X main.VERSION=$(date -u +%Y%m%d) -s -w" github.com/xtaci/kcptun/client && go get -ldflags "-X main.VERSION=$(date -u +%Y%m%d) -s -w" github.com/xtaci/kcptun/server
+
+FROM alpine:3.6
+COPY --from=builder /go/bin /bin
 EXPOSE 29900/udp
 EXPOSE 12948


### PR DESCRIPTION
The current image takes up 331 MB disk space and compressed size up 119 MB
while most of them are golang build tools not necessary for running kcptun  .
Since ldd shows the binary only needs musl ,simply copy to an alpine image would work.
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/xtaci/kcptun/pull/509%23issuecomment-338384333%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/xtaci/kcptun/pull/509%23issuecomment-338384333%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22cool%22%2C%20%22created_at%22%3A%20%222017-10-21T11%3A15%3A57Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars3.githubusercontent.com/u/2346725%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/xtaci%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [ ] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/xtaci/kcptun/pull/509#issuecomment-338384333'>General Comment</a></b>
- <a href='https://github.com/xtaci'><img border=0 src='https://avatars3.githubusercontent.com/u/2346725?v=4' height=16 width=16></a> cool


<a href='https://www.codereviewhub.com/xtaci/kcptun/pull/509?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/xtaci/kcptun/pull/509?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/xtaci/kcptun/pull/509'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>