### PR TITLE
snmplog: only format the log file name, not the whole path

### DIFF
--- a/client/main.go
+++ b/client/main.go
@@ -18,6 +18,8 @@ import (
 	"github.com/urfave/cli"
 	kcp "github.com/xtaci/kcp-go"
 	"github.com/xtaci/smux"
+
+    "path/filepath"
 )
 
 var (
@@ -476,7 +478,11 @@ func snmpLogger(path string, interval int) {
 	for {
 		select {
 		case <-ticker.C:
-			f, err := os.OpenFile(time.Now().Format(path), os.O_RDWR|os.O_CREATE|os.O_APPEND, 0666)
+            // TODO : Please review
+            // split path into dirname and filename
+            logdir, logfile := filepath.Split(path)
+            // only format logfile
+			f, err := os.OpenFile(logdir + time.Now().Format(logfile), os.O_RDWR|os.O_CREATE|os.O_APPEND, 0666)
 			if err != nil {
 				log.Println(err)
 				return

--- a/server/main.go
+++ b/server/main.go
@@ -19,6 +19,8 @@ import (
 	"github.com/urfave/cli"
 	kcp "github.com/xtaci/kcp-go"
 	"github.com/xtaci/smux"
+    "path/filepath"
+
 )
 
 var (
@@ -400,7 +402,11 @@ func snmpLogger(path string, interval int) {
 	for {
 		select {
 		case <-ticker.C:
-			f, err := os.OpenFile(time.Now().Format(path), os.O_RDWR|os.O_CREATE|os.O_APPEND, 0666)
+            // TODO: Please review
+            // split path into dirname and filename
+            logdir, logfile := filepath.Split(path)
+            // only format logfile
+			f, err := os.OpenFile(logdir + time.Now().Format(logfile), os.O_RDWR|os.O_CREATE|os.O_APPEND, 0666)
 			if err != nil {
 				log.Println(err)
 				return


### PR DESCRIPTION
It seems to be indent problem w.r.t code review. I am not sure whether you have the whole process to deal with that, so I just leave this way. If there is any problems with this PR, please contact me, thanks.
<a href='#crh-start'></a><a href='#crh-data-%7B%22approved%22%3A%20%7B%22https%3A//github.com/mateomartin1998%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars2.githubusercontent.com/u/39933868%3Fv%3D4%22%7D%7D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/xtaci/kcptun/pull/600%23issuecomment-398964017%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22%3Ashipit%3A%22%2C%20%22created_at%22%3A%20%222018-06-21T03%3A21%3A54Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars2.githubusercontent.com/u/39933868%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/mateomartin1998%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%7D%2C%20%22processed%22%3A%20%5B%22https%3A//github.com/xtaci/kcptun/pull/600%23issuecomment-398964017%22%5D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>

<img src='http://www.codereviewhub.com/site/github-approved-avatar.png'><a href='https://github.com/mateomartin1998'><img src='https://avatars2.githubusercontent.com/u/39933868?v=4' width=34 height=34></a>

<a href='https://www.codereviewhub.com/xtaci/kcptun/pull/600?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/xtaci/kcptun/pull/600?approve=0'><img src='http://www.codereviewhub.com/site/github-undo-approve.png' height=26></a>&nbsp;<a href='https://github.com/xtaci/kcptun/pull/600'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>