### PR TITLE
upgrade alpine to v3.9 in docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ RUN apk update && \
     apk add git
 RUN go get -ldflags "-X main.VERSION=$(date -u +%Y%m%d) -s -w" github.com/xtaci/kcptun/client && go get -ldflags "-X main.VERSION=$(date -u +%Y%m%d) -s -w" github.com/xtaci/kcptun/server
 
-FROM alpine:3.6
+FROM alpine:3.9
 COPY --from=builder /go/bin /bin
 EXPOSE 29900/udp
 EXPOSE 12948


### PR DESCRIPTION
Current version (v3.6) will be end support on 2019-05-01.

see: https://wiki.alpinelinux.org/wiki/Alpine_Linux:Releases