### PR TITLE
Log connecting ip

### DIFF
--- a/client/main.go
+++ b/client/main.go
@@ -28,7 +28,7 @@ var VERSION = "SELFBUILD"
 // A pool for stream copying
 var xmitBuf sync.Pool
 
-func handleClient(sess *smux.Session, p1 io.ReadWriteCloser, quiet bool) {
+func handleClient(sess *smux.Session, p1 *net.TCPConn, quiet bool) {
 	logln := func(v ...interface{}) {
 		if !quiet {
 			log.Println(v...)
@@ -43,8 +43,8 @@ func handleClient(sess *smux.Session, p1 io.ReadWriteCloser, quiet bool) {
 
 	defer p2.Close()
 
-	logln("stream opened", p2.ID())
-	defer logln("stream closed", p2.ID())
+	logln("stream opened", p2.ID(), " from:", p1.RemoteAddr())
+	defer logln("stream closed", p2.ID(), "from:", p1.RemoteAddr())
 
 	// start tunnel & wait for tunnel termination
 	streamCopy := func(dst io.Writer, src io.ReadCloser) chan struct{} {

--- a/client/main.go
+++ b/client/main.go
@@ -29,22 +29,22 @@ var VERSION = "SELFBUILD"
 var xmitBuf sync.Pool
 
 func handleClient(sess *smux.Session, p1 *net.TCPConn, quiet bool) {
-	logln := func(v ...interface{}) {
+	logln := func(s string, v ...interface{}) {
 		if !quiet {
-			log.Println(v...)
+			log.Printf(s, v...)
 		}
 	}
 	defer p1.Close()
 	p2, err := sess.OpenStream()
 	if err != nil {
-		logln(err)
+		logln("%s", err)
 		return
 	}
 
 	defer p2.Close()
 
-	logln("stream opened", p2.ID(), " from:", p1.RemoteAddr())
-	defer logln("stream closed", p2.ID(), "from:", p1.RemoteAddr())
+	logln("stream opened %s(%d)", p1.RemoteAddr(), p2.ID())
+	defer logln("stream closed %s(%d)", p1.RemoteAddr(), p2.ID())
 
 	// start tunnel & wait for tunnel termination
 	streamCopy := func(dst io.Writer, src io.ReadCloser) chan struct{} {


### PR DESCRIPTION
Someone like me have several client to connect kcp client, It would be help if log the connecting ip information.

the log will be like this:
```
2019/06/11 10:34:17 main.go:34: stream opened 3  from: 127.0.0.1:58944
2019/06/11 10:34:20 main.go:34: stream opened 5  from: 10.229.33.41:62574
2019/06/11 10:34:22 main.go:34: stream opened 15  from: 10.229.33.41:62590
2019/06/11 10:34:30 main.go:34: stream opened 19  from: 10.229.33.41:62598
2019/06/11 10:34:31 main.go:34: stream opened 21  from: 127.0.0.1:58946
2019/06/11 10:34:34 main.go:34: stream opened 25  from: 127.0.0.1:58950
```