### PR TITLE
fix: listen unix "bind: address already in use" issue

### DIFF
--- a/client/main.go
+++ b/client/main.go
@@ -39,10 +39,11 @@ import (
 	"github.com/fatih/color"
 	"github.com/pkg/errors"
 	"github.com/urfave/cli"
-	kcp "github.com/xtaci/kcp-go/v5"
-	"github.com/xtaci/kcptun/std"
+	"github.com/xtaci/kcp-go/v5"
 	"github.com/xtaci/qpp"
 	"github.com/xtaci/smux"
+
+	"github.com/xtaci/kcptun/std"
 )
 
 const (
@@ -310,6 +311,7 @@ func main() {
 		if isUnix {
 			addr, err := net.ResolveUnixAddr("unix", config.LocalAddr)
 			checkError(err)
+			_ = os.Remove(config.LocalAddr)
 			listener, err = net.ListenUnix("unix", addr)
 			checkError(err)
 		} else {


### PR DESCRIPTION
kcptun client will throw error when binding use unix socket: `client_linux_amd64[681666]:  listen unix /var/run/kcptun.sock: bind: address already in use`.